### PR TITLE
Add Bump.sh to Documentation tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ Awesome automation to improve your developer experience.
 - [Redocly](https://redocly.com/) - Beautiful API documentation loved by teams and API consumers. Brought to you by the open-source extraordinaires behind Redoc.
 - [RunKit](https://runkit.com/) - RunKit is a node playground in your browser.
 - [Slate](https://github.com/slatedocs/slate) - Slate helps you create beautiful, intelligent, responsive API documentation.
+- [Bump.sh](https://bump.sh/) - Publish user-friendly API documentation portals, centralizing all API docs, whether OpenAPI or AsyncAPI.
 
 ### Knowledge management
 

--- a/readme.md
+++ b/readme.md
@@ -106,13 +106,13 @@ Awesome automation to improve your developer experience.
 
 ### Documentation
 
+- [Bump.sh](https://bump.sh/) - Publish user-friendly API documentation portals, centralizing all API docs, whether OpenAPI or AsyncAPI.
 - [Docusaurus](https://docusaurus.io/) - Build optimized websites quickly, focus on your content.
 - [GitBook](https://www.gitbook.com/) - GitBook helps you publish beautiful docs for your users and centralize your teams' knowledge for advanced collaboration.
 - [ReadMe](https://readme.com/) - Developer hubs that meet your users where they are.
 - [Redocly](https://redocly.com/) - Beautiful API documentation loved by teams and API consumers. Brought to you by the open-source extraordinaires behind Redoc.
 - [RunKit](https://runkit.com/) - RunKit is a node playground in your browser.
 - [Slate](https://github.com/slatedocs/slate) - Slate helps you create beautiful, intelligent, responsive API documentation.
-- [Bump.sh](https://bump.sh/) - Publish user-friendly API documentation portals, centralizing all API docs, whether OpenAPI or AsyncAPI.
 
 ### Knowledge management
 


### PR DESCRIPTION
Hi there, thanks for your awesome lists!

I'm suggesting the addition of Bump.sh to the list of Documentation tools.

Why add this one, together with Redocly, Slate or Readme? 
They're all great tools; now, we all have differences. More options in this list can help devs make a more educated pick. Bump.sh is different from Slate and similar to Redocly and Readme in the sense that it generates docs directly from OpenAPI and AsyncAPI files (not just markdown). It's different from those for two main reasons: 1. it supports AsyncAPI on top of OpenAPI 2. it offers additional features of versioning and historization of docs, which Redocly and Readme do not have.

Let me know if there's anything I should change!